### PR TITLE
Hold with specific expiration

### DIFF
--- a/.solcover.js
+++ b/.solcover.js
@@ -1,4 +1,4 @@
 module.exports = {
     testrpcOptions: '-p 8555 -e 1000000 -g 0x01',
-    copyPackages: ['openzeppelin-solidity']
+    copyPackages: ['@openzeppelin/contracts']
 };

--- a/.solcover.js
+++ b/.solcover.js
@@ -1,4 +1,4 @@
 module.exports = {
     testrpcOptions: '-p 8555 -e 1000000 -g 0x01',
-    copyPackages: ['@openzeppelin/contracts']
+    copyPackages: ['openzeppelin-solidity']
 };

--- a/contracts/Holdable.sol
+++ b/contracts/Holdable.sol
@@ -325,7 +325,7 @@ contract Holdable is IHoldable, ERC20 {
         return true;
     }
 
-    function _setHoldToExecuted(string memory operationId, uint256 value, uint256 heldBalanceDecrease) private {
+    function _setHoldToExecuted(string memory operationId, uint256 value, uint256 heldBalanceDecrease) internal {
         _decreaseHeldBalance(operationId, heldBalanceDecrease);
 
         Hold storage executableHold = holds[operationId.toHash()];
@@ -340,7 +340,7 @@ contract Holdable is IHoldable, ERC20 {
         );
     }
 
-    function _setHoldToExecutedAndKeptOpen(string memory operationId, uint256 value, uint256 heldBalanceDecrease) private {
+    function _setHoldToExecutedAndKeptOpen(string memory operationId, uint256 value, uint256 heldBalanceDecrease) internal {
         _decreaseHeldBalance(operationId, heldBalanceDecrease);
 
         Hold storage executableHold = holds[operationId.toHash()];

--- a/contracts/Holdable.sol
+++ b/contracts/Holdable.sol
@@ -1,13 +1,11 @@
 pragma solidity ^0.5.0;
 
-import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+import "openzeppelin-solidity/contracts/token/ERC20/ERC20.sol";
 import "./IHoldable.sol";
 import "solidity-string-util/contracts/StringUtil.sol";
 
 
 contract Holdable is IHoldable, ERC20 {
-
-    using SafeMath for uint256;
     using StringUtil for string;
 
     struct Hold {
@@ -78,7 +76,7 @@ contract Holdable is IHoldable, ERC20 {
     ) public returns (bool)
     {
         _checkHold(to);
-        require(expiration > now || expiration == 0, "Expiration date must be greater than block timestamp or zero");
+        _checkExpiration(expiration);
 
         return _hold(
             operationId,
@@ -101,7 +99,7 @@ contract Holdable is IHoldable, ERC20 {
     ) public returns (bool)
     {
         _checkHoldFrom(to, from);
-        require(expiration > now || expiration == 0, "Expiration date must be greater than block timestamp or zero");
+        _checkExpiration(expiration);
 
         return _hold(
             operationId,
@@ -147,7 +145,7 @@ contract Holdable is IHoldable, ERC20 {
 
     function renewHoldWithExpirationDate(string memory operationId, uint256 expiration) public returns (bool) {
         _checkRenewableHold(operationId);
-        require(expiration > now || expiration == 0, "Expiration date must be greater than block timestamp or zero");
+        _checkExpiration(expiration);
 
         return _renewHold(operationId, expiration);
     }
@@ -393,5 +391,9 @@ contract Holdable is IHoldable, ERC20 {
             renewableHold.origin == msg.sender || renewableHold.issuer == msg.sender,
             "The hold can only be renewed by the issuer or the payer"
         );
+    }
+
+    function _checkExpiration(uint256 expiration) private view {
+        require(expiration > now || expiration == 0, "Expiration date must be greater than block timestamp or zero");
     }
 }

--- a/contracts/IHoldable.sol
+++ b/contracts/IHoldable.sol
@@ -26,10 +26,26 @@ interface IHoldable {
         uint256 value,
         uint256 timeToExpiration
     ) external returns (bool);
+    function holdWithExpirationDate(
+        string calldata operationId,
+        address to,
+        address notary,
+        uint256 value,
+        uint256 expiration
+    ) external returns (bool);
+    function holdFromWithExpirationDate(
+        string calldata operationId,
+        address from,
+        address to,
+        address notary,
+        uint256 value,
+        uint256 expiration
+    ) external returns (bool);
     function releaseHold(string calldata operationId) external returns (bool);
     function executeHold(string calldata operationId, uint256 value) external returns (bool);
     function executeHoldAndKeepOpen(string calldata operationId, uint256 value) external returns (bool);
     function renewHold(string calldata operationId, uint256 timeToExpiration) external returns (bool);
+    function renewHoldWithExpirationDate(string calldata operationId, uint256 expiration) external returns (bool);
     function retrieveHoldData(string calldata operationId) external view returns (
         address from,
         address to,
@@ -63,4 +79,17 @@ interface IHoldable {
     event HoldRenewed(address indexed holdIssuer, string operationId, uint256 oldExpiration, uint256 newExpiration);
     event AuthorizedHoldOperator(address indexed operator, address indexed account);
     event RevokedHoldOperator(address indexed operator, address indexed account);
+
+    /**
+     * ERC20 Interface
+     */
+    function totalSupply() external view returns (uint256);
+    function balanceOf(address account) external view returns (uint256);
+    function transfer(address recipient, uint256 amount) external returns (bool);
+    function allowance(address owner, address spender) external view returns (uint256);
+    function approve(address spender, uint256 amount) external returns (bool);
+    function transferFrom(address sender, address recipient, uint256 amount) external returns (bool);
+
+    event Transfer(address indexed from, address indexed to, uint256 value);
+    event Approval(address indexed owner, address indexed spender, uint256 value);
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,11 +13,6 @@
         "regenerator-runtime": "^0.13.2"
       }
     },
-    "@openzeppelin/contracts": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@openzeppelin/contracts/-/contracts-2.4.0.tgz",
-      "integrity": "sha512-xeKP59REgow5TPBJh3S9BRIm7DDG+Rz3Nt4ANWGUkjk4305DHpyUD5CyMJ6nd2JMmZuFyx4mjvvlCtSJLRnN6w=="
-    },
     "@sindresorhus/is": {
       "version": "0.14.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.14.0.tgz",
@@ -6165,6 +6160,11 @@
       "requires": {
         "wrappy": "1"
       }
+    },
+    "openzeppelin-solidity": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/openzeppelin-solidity/-/openzeppelin-solidity-2.4.0.tgz",
+      "integrity": "sha512-533gc5jkspxW5YT0qJo02Za5q1LHwXK9CJCc48jNj/22ncNM/3M/3JfWLqfpB90uqLwOKOovpl0JfaMQTR+gXQ=="
     },
     "optimist": {
       "version": "0.6.1",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An extension to the ERC-20 standard token, which allows tokens to be put on hold. This guarantees a future transfer and makes the held tokens unavailable for transfer in the mean time. Holds are similar to escrows in that are firm and lead to final settlement.",
   "main": "truffle-config.js",
   "dependencies": {
-    "@openzeppelin/contracts": "^2.1.0",
+    "openzeppelin-solidity": "^2.1.0",
     "solidity-string-util": "^0.1.0"
   },
   "devDependencies": {

--- a/test/Holdable.js
+++ b/test/Holdable.js
@@ -158,7 +158,7 @@ contract('Holdable', (accounts) => {
             );
         });
 
-        it.only('should successfully create a perpetual hold and emit a HoldCreated event', async() => {
+        it('should successfully create a perpetual hold and emit a HoldCreated event', async() => {
             const tx = await holdableInterface.hold(
               operationId,
               payee,
@@ -480,16 +480,19 @@ contract('Holdable', (accounts) => {
         });
 
         it('should successfully create a hold and emit a HoldCreated event', async() => {
+            const blockTimestamp = await getBlockTimestamp();
+            const expectedExpiration = blockTimestamp + ONE_DAY
+
             const tx = await holdableInterface.holdWithExpirationDate(
               operationId,
               payee,
               notary,
               1,
-              ONE_DAY,
+              expectedExpiration,
               {from: payer}
             );
 
-            const blockTimestamp = await getBlockTimestamp()
+
 
             await verifyHoldCreated(
                 holdableInterface,
@@ -500,7 +503,7 @@ contract('Holdable', (accounts) => {
                 payee,
                 notary,
                 1,
-                blockTimestamp + ONE_DAY
+                expectedExpiration
             );
         });
 

--- a/test/Holdable.js
+++ b/test/Holdable.js
@@ -128,7 +128,8 @@ contract('Holdable', (accounts) => {
                     4,
                     0,
                     {from: payer}
-                )
+                ),
+              'Amount of the hold can\'t be greater than the balance of the origin'
             );
         });
 
@@ -154,6 +155,29 @@ contract('Holdable', (accounts) => {
                 notary,
                 1,
                 blockTimestamp + ONE_DAY
+            );
+        });
+
+        it.only('should successfully create a perpetual hold and emit a HoldCreated event', async() => {
+            const tx = await holdableInterface.hold(
+              operationId,
+              payee,
+              notary,
+              1,
+              0,
+              {from: payer}
+            );
+
+            await verifyHoldCreated(
+              holdableInterface,
+              tx,
+              operationId,
+              payer,
+              payer,
+              payee,
+              notary,
+              1,
+              0
             );
         });
     });
@@ -276,7 +300,8 @@ contract('Holdable', (accounts) => {
                     4,
                     0,
                     {from: authorizedOperator}
-                )
+                ),
+              'Amount of the hold can\'t be greater than the balance of the origin'
             );
         });
 
@@ -290,11 +315,38 @@ contract('Holdable', (accounts) => {
                     1,
                     0,
                     {from: unauthorizedOperator}
-                )
+                ),
+              'This operator is not authorized'
             );
         });
 
         it('should successfully create a hold and emit a HoldCreated event', async() => {
+            const tx = await holdableInterface.holdFrom(
+                operationId,
+                payer,
+                payee,
+                notary,
+                1,
+                ONE_DAY,
+                {from: authorizedOperator}
+            );
+
+            const blockTimestamp = await getBlockTimestamp()
+
+            await verifyHoldCreated(
+                holdableInterface,
+                tx,
+                operationId,
+                authorizedOperator,
+                payer,
+                payee,
+                notary,
+                1,
+                blockTimestamp + ONE_DAY
+            );
+        });
+
+        it('should successfully create a perpetual hold and emit a HoldCreated event', async() => {
             const tx = await holdableInterface.holdFrom(
                 operationId,
                 payer,
@@ -408,7 +460,8 @@ contract('Holdable', (accounts) => {
                 4,
                 0,
                 {from: payer}
-              )
+              ),
+              'Amount of the hold can\'t be greater than the balance of the origin'
             );
         });
 
@@ -432,9 +485,11 @@ contract('Holdable', (accounts) => {
               payee,
               notary,
               1,
-              0,
+              ONE_DAY,
               {from: payer}
             );
+
+            const blockTimestamp = await getBlockTimestamp()
 
             await verifyHoldCreated(
                 holdableInterface,
@@ -445,7 +500,30 @@ contract('Holdable', (accounts) => {
                 payee,
                 notary,
                 1,
-                0
+                blockTimestamp + ONE_DAY
+            );
+        });
+
+        it('should successfully create a perpetual hold and emit a HoldCreated event', async() => {
+            const tx = await holdableInterface.holdWithExpirationDate(
+              operationId,
+              payee,
+              notary,
+              1,
+              0,
+              {from: payer}
+            );
+
+            await verifyHoldCreated(
+              holdableInterface,
+              tx,
+              operationId,
+              payer,
+              payer,
+              payee,
+              notary,
+              1,
+              0
             );
         });
     });
@@ -568,7 +646,8 @@ contract('Holdable', (accounts) => {
                 4,
                 0,
                 {from: authorizedOperator}
-              )
+              ),
+              'Amount of the hold can\'t be greater than the balance of the origin'
             );
         });
 
@@ -597,7 +676,8 @@ contract('Holdable', (accounts) => {
                 1,
                 0,
                 {from: unauthorizedOperator}
-              )
+              ),
+              'This operator is not authorized'
             );
         });
 
@@ -625,6 +705,30 @@ contract('Holdable', (accounts) => {
               notary,
               1,
               expiration
+            );
+        });
+
+        it('should successfully create a perpetual hold and emit a HoldCreated event', async() => {
+            const tx = await holdableInterface.holdFromWithExpirationDate(
+              operationId,
+              payer,
+              payee,
+              notary,
+              1,
+              0,
+              {from: authorizedOperator}
+            );
+
+            await verifyHoldCreated(
+              holdableInterface,
+              tx,
+              operationId,
+              authorizedOperator,
+              payer,
+              payee,
+              notary,
+              1,
+              0
             );
         });
     });


### PR DESCRIPTION
Holdable.sol:
* Added `holdWithExpirationDate` & `holdFromWithExpirationDate`
* Added `renewHoldWithExpirationDate`. It was not in the ADR, but seems to make sense with the other two functions 
* Moved events to internal functions
* `_executeHold` decreases the held balance again
* functions that are not meant to be used by contracts that extend Holdable are all private

IHoldable.sol
* Added the ERC20 interface to use all the functions the Holdable includes in one interface

Holdable.js
* Added more checks that a hold is saved correctly on the blockchain
* The holdable interface is used to interact with contract instead of the contract itself to test that all functions are included in it
