### PR TITLE
Introduce new parameter to do the transfer in the execute optional

### DIFF
--- a/contracts/Holdable.sol
+++ b/contracts/Holdable.sol
@@ -193,7 +193,7 @@ contract Holdable is IHoldable, ERC20 {
         require (operators[msg.sender][operator] == false, "The operator is already authorized");
 
         operators[msg.sender][operator] = true;
-        emit AuthorizedHoldOperator(operator, msg.sender);
+        emit HoldOperatorAuthorized(operator, msg.sender);
         return true;
     }
 

--- a/contracts/Holdable.sol
+++ b/contracts/Holdable.sol
@@ -290,15 +290,6 @@ contract Holdable is IHoldable, ERC20 {
     function _executeHold(string memory operationId, uint256 value, bool keepOpenIfHoldHasBalance) internal returns (bool) {
         Hold storage executableHold = holds[operationId.toHash()];
 
-        require(
-            executableHold.status == HoldStatusCode.Ordered || executableHold.status == HoldStatusCode.ExecutedAndKeptOpen,
-            "A hold can only be executed in status Ordered or ExecutedAndKeptOpen"
-        );
-        require(value != 0, "Value must be greater than zero");
-        require(executableHold.notary == msg.sender, "The hold can only be executed by the notary");
-        require(!_isExpired(executableHold.expiration), "The hold has already expired");
-        require(value <= executableHold.value, "The value should be equal or less than the held amount");
-
         if (keepOpenIfHoldHasBalance && ((executableHold.value - value) > 0)) {
             _setHoldToExecutedAndKeptOpen(
                 executableHold,
@@ -341,6 +332,7 @@ contract Holdable is IHoldable, ERC20 {
         uint256 heldBalanceDecrease
     ) internal
     {
+        _checkExecuteHold(executableHold, value);
         _decreaseHeldBalance(executableHold, heldBalanceDecrease);
 
         executableHold.status = HoldStatusCode.Executed;
@@ -361,6 +353,7 @@ contract Holdable is IHoldable, ERC20 {
         uint256 heldBalanceDecrease
     ) internal
     {
+        _checkExecuteHold(executableHold, value);
         _decreaseHeldBalance(executableHold, heldBalanceDecrease);
 
         executableHold.status = HoldStatusCode.ExecutedAndKeptOpen;
@@ -407,6 +400,17 @@ contract Holdable is IHoldable, ERC20 {
         require(to != address(0), "Payee address must not be zero address");
         require(from != address(0), "Payer address must not be zero address");
         require(_isDefaultOperatorOrOperator(msg.sender, from), "This operator is not authorized");
+    }
+
+    function _checkExecuteHold(Hold memory executableHold, uint256 value) private {
+        require(
+            executableHold.status == HoldStatusCode.Ordered || executableHold.status == HoldStatusCode.ExecutedAndKeptOpen,
+            "A hold can only be executed in status Ordered or ExecutedAndKeptOpen"
+        );
+        require(value != 0, "Value must be greater than zero");
+        require(executableHold.notary == msg.sender, "The hold can only be executed by the notary");
+        require(!_isExpired(executableHold.expiration), "The hold has already expired");
+        require(value <= executableHold.value, "The value should be equal or less than the held amount");
     }
 
     function _checkRenewableHold(Hold storage renewableHold) private view {

--- a/contracts/IHoldable.sol
+++ b/contracts/IHoldable.sol
@@ -77,7 +77,7 @@ interface IHoldable {
     uint256 transferredValue);
     event HoldReleased(address indexed holdIssuer, string operationId, HoldStatusCode status);
     event HoldRenewed(address indexed holdIssuer, string operationId, uint256 oldExpiration, uint256 newExpiration);
-    event AuthorizedHoldOperator(address indexed operator, address indexed account);
+    event HoldOperatorAuthorized(address indexed operator, address indexed account);
     event RevokedHoldOperator(address indexed operator, address indexed account);
 
     /**

--- a/contracts/mocks/HoldableMock.sol
+++ b/contracts/mocks/HoldableMock.sol
@@ -7,8 +7,6 @@ contract HoldableMock is Holdable {
     bool isExpiredSet;
     bool isExpired;
 
-    event RevokedHoldOperator(address indexed operator, address indexed account);
-
     function mint(address account, uint256 value) external {
         _mint(account, value);
     }

--- a/contracts/mocks/HoldableMock.sol
+++ b/contracts/mocks/HoldableMock.sol
@@ -7,12 +7,26 @@ contract HoldableMock is Holdable {
     bool isExpiredSet;
     bool isExpired;
 
+    event RevokedHoldOperator(address indexed operator, address indexed account);
+
     function mint(address account, uint256 value) external {
         _mint(account, value);
     }
 
     function changeHoldExpirationTime(string calldata operationId, uint256 _expiration) external {
         holds[operationId.toHash()].expiration = _expiration;
+    }
+
+    function executeHoldToBurn(string calldata operationId) external {
+        Hold storage hold = holds[operationId.toHash()];
+
+        _executeHold(
+            operationId,
+            hold.value,
+            false,
+            false
+        );
+        _burn(hold.origin, hold.value);
     }
 
     function setExpired(bool _isExpired) external {

--- a/test/Holdable.js
+++ b/test/Holdable.js
@@ -1699,13 +1699,13 @@ contract('Holdable', (accounts) => {
     });
 
     describe('authorizeHoldOperator', async() => {
-        it('should authorize an operator and emit a AuthorizedHoldOperator event', async() => {
+        it('should authorize an operator and emit a HoldOperatorAuthorized event', async() => {
             const tx = await holdableInterface.authorizeHoldOperator(authorizedOperator, {from: payer});
 
             const isAuthorized = await holdableInterface.isHoldOperatorFor(authorizedOperator, payer);
             assert.strictEqual(isAuthorized, true, 'Operator has not been authorized');
 
-            truffleAssert.eventEmitted(tx, 'AuthorizedHoldOperator', (_event) => {
+            truffleAssert.eventEmitted(tx, 'HoldOperatorAuthorized', (_event) => {
                 return _event.operator === authorizedOperator && _event.account === payer;
             });
         });

--- a/test/Holdable.js
+++ b/test/Holdable.js
@@ -1277,6 +1277,37 @@ contract('Holdable', (accounts) => {
         });
     });
 
+    describe('executeHoldToBurn', async() => {
+        beforeEach(async() => {
+            await holdableInterface.hold(
+                operationId,
+                payee,
+                notary,
+                2,
+                ONE_DAY,
+                {from: payer}
+            );
+        });
+
+        it('It should do during the execute hold a burn operation instead a transfer.', async() => {
+            const tx = await holdable.executeHoldToBurn(operationId, {from: notary});
+
+            const balanceOfPayer = await holdableInterface.balanceOf(payer);
+            assert.strictEqual(balanceOfPayer.toNumber(), 1, 'Balance of payer not updated after mint');
+
+            const balanceOfPayee = await holdableInterface.balanceOf(payee);
+            assert.strictEqual(balanceOfPayee.toNumber(), 0, 'Balance of payee updated after mint');
+
+            truffleAssert.eventEmitted(tx, 'Transfer', (_event) => {
+                return _event.from === payer &&
+                    _event.to ===  '0x0000000000000000000000000000000000000000' &&
+                    _event.value.toNumber() === 2
+                    ;
+            });
+
+        });
+    });
+
     describe('renewHold', async() => {
         beforeEach(async() => {
             await holdableInterface.hold(


### PR DESCRIPTION
In the current implementation of `_executeHold`, It is verifying the restrictions to execute, change the hold structure and make an ERC20 transfer.

In some cases, the execute hold it will need to check the requires of the execute hold, but not transfer at the same time.

By this reason, We propose to introduce a new boolean parameter in `_executeHold` called `doTransfer` who permits call to RC20 `_transfer` or not.