### PR TITLE
Be able to renew holds after executedAndKeptOpen

### DIFF
--- a/contracts/Holdable.sol
+++ b/contracts/Holdable.sol
@@ -410,7 +410,8 @@ contract Holdable is IHoldable, ERC20 {
     }
 
     function _checkRenewableHold(Hold storage renewableHold) private view {
-        require(renewableHold.status == HoldStatusCode.Ordered, "A hold can only be renewed in status Ordered");
+        require(renewableHold.status == HoldStatusCode.Ordered || renewableHold.status == HoldStatusCode.ExecutedAndKeptOpen,
+            "A hold can only be renewed in status Ordered or ExecutedAndKeptOpen");
         require(!_isExpired(renewableHold.expiration), "An expired hold can not be renewed");
         require(
             renewableHold.origin == msg.sender || renewableHold.issuer == msg.sender,

--- a/contracts/Holdable.sol
+++ b/contracts/Holdable.sol
@@ -410,8 +410,10 @@ contract Holdable is IHoldable, ERC20 {
     }
 
     function _checkRenewableHold(Hold storage renewableHold) private view {
-        require(renewableHold.status == HoldStatusCode.Ordered || renewableHold.status == HoldStatusCode.ExecutedAndKeptOpen,
-            "A hold can only be renewed in status Ordered or ExecutedAndKeptOpen");
+        require(
+            renewableHold.status == HoldStatusCode.Ordered || renewableHold.status == HoldStatusCode.ExecutedAndKeptOpen,
+            "A hold can only be renewed in status Ordered or ExecutedAndKeptOpen"
+        );
         require(!_isExpired(renewableHold.expiration), "An expired hold can not be renewed");
         require(
             renewableHold.origin == msg.sender || renewableHold.issuer == msg.sender,

--- a/test/Holdable.js
+++ b/test/Holdable.js
@@ -1283,7 +1283,7 @@ contract('Holdable', (accounts) => {
                 operationId,
                 payee,
                 notary,
-                1,
+                2,
                 ONE_DAY,
                 {from: payer}
             );
@@ -1319,7 +1319,7 @@ contract('Holdable', (accounts) => {
         it('should revert if the hold has been executed', async() => {
             await holdableInterface.executeHold(
                 operationId,
-                1,
+                2,
                 {from: notary}
             );
 
@@ -1329,7 +1329,7 @@ contract('Holdable', (accounts) => {
                     ONE_DAY,
                     {from: notary}
                 ),
-                'A hold can only be renewed in status Ordered'
+                'A hold can only be renewed in status Ordered or ExecutedAndKeptOpen'
             );
         });
 
@@ -1382,7 +1382,7 @@ contract('Holdable', (accounts) => {
             );
 
             const balanceOnHoldOfPayer = await holdableInterface.balanceOnHold(payer);
-            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 1);
+            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 2);
 
             truffleAssert.eventEmitted(tx, 'HoldRenewed', (_event) => {
                 return _event.holdIssuer === payer &&
@@ -1410,7 +1410,7 @@ contract('Holdable', (accounts) => {
             );
 
             const balanceOnHoldOfPayer = await holdableInterface.balanceOnHold(payer);
-            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 1);
+            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 2);
 
             truffleAssert.eventEmitted(tx, 'HoldRenewed', (_event) => {
                 return _event.holdIssuer === payer &&
@@ -1418,6 +1418,71 @@ contract('Holdable', (accounts) => {
                     _event.oldExpiration.toNumber() === originalHold.expiration.toNumber() &&
                     _event.newExpiration.toNumber() === 0
                 ;
+            });
+        });
+
+        it('It should execute and keep open, renew and emit a HoldRenewed when called by the payer with a non zero value', async() => {
+            await holdableInterface.executeHoldAndKeepOpen(operationId, 1, {from: notary});
+            const originalHold = await holdableInterface.retrieveHoldData(operationId);
+
+            // use the mock contracts changeHoldExpirationTime function to reduce the expiration time by twelve hours
+            const reducedOriginalExpiration = originalHold.expiration.toNumber() - TWELVE_HOURS;
+            await holdable.changeHoldExpirationTime(operationId, reducedOriginalExpiration);
+
+            const tx = await holdableInterface.renewHold(
+                operationId,
+                ONE_DAY,
+                {from: payer}
+            );
+
+            const blockTimestamp = await getBlockTimestamp();
+            const expectedExpiration = blockTimestamp + ONE_DAY;
+
+            const renewedHold = await holdableInterface.retrieveHoldData(operationId);
+            assert.strictEqual(
+                renewedHold.expiration.toNumber(),
+                expectedExpiration,
+                'Hold was not renewed correctly'
+            );
+
+            const balanceOnHoldOfPayer = await holdableInterface.balanceOnHold(payer);
+            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 1);
+
+            truffleAssert.eventEmitted(tx, 'HoldRenewed', (_event) => {
+                return _event.holdIssuer === payer &&
+                    _event.operationId === operationId &&
+                    _event.oldExpiration.toNumber() === reducedOriginalExpiration &&
+                    _event.newExpiration.toNumber() === expectedExpiration
+                    ;
+            });
+        });
+
+        it('It should execute and keep open, renew and emit a HoldRenewed when called by the payer with a zero value', async() => {
+            await holdableInterface.executeHoldAndKeepOpen(operationId, 1, {from: notary});
+            const originalHold = await holdableInterface.retrieveHoldData(operationId);
+
+            const tx = await holdableInterface.renewHold(
+                operationId,
+                0,
+                {from: payer}
+            );
+
+            const renewedHold = await holdableInterface.retrieveHoldData(operationId);
+            assert.strictEqual(
+                renewedHold.expiration.toNumber(),
+                0,
+                'Hold was not renewed correctly'
+            );
+
+            const balanceOnHoldOfPayer = await holdableInterface.balanceOnHold(payer);
+            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 1);
+
+            truffleAssert.eventEmitted(tx, 'HoldRenewed', (_event) => {
+                return _event.holdIssuer === payer &&
+                    _event.operationId === operationId &&
+                    _event.oldExpiration.toNumber() === originalHold.expiration.toNumber() &&
+                    _event.newExpiration.toNumber() === 0
+                    ;
             });
         });
     });
@@ -1428,7 +1493,7 @@ contract('Holdable', (accounts) => {
               operationId,
               payee,
               notary,
-              1,
+              2,
               ONE_DAY,
               {from: payer}
             );
@@ -1464,7 +1529,7 @@ contract('Holdable', (accounts) => {
         it('should revert if the hold has been executed', async() => {
             await holdableInterface.executeHold(
               operationId,
-              1,
+              2,
               {from: notary}
             );
 
@@ -1474,7 +1539,7 @@ contract('Holdable', (accounts) => {
                 ONE_DAY,
                 {from: notary}
               ),
-              'A hold can only be renewed in status Ordered'
+              'A hold can only be renewed in status Ordered or ExecutedAndKeptOpen'
             );
         });
 
@@ -1535,7 +1600,7 @@ contract('Holdable', (accounts) => {
             );
 
             const balanceOnHoldOfPayer = await holdableInterface.balanceOnHold(payer);
-            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 1);
+            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 2);
 
             truffleAssert.eventEmitted(tx, 'HoldRenewed', (_event) => {
                 return _event.holdIssuer === payer &&
@@ -1563,7 +1628,7 @@ contract('Holdable', (accounts) => {
             );
 
             const balanceOnHoldOfPayer = await holdableInterface.balanceOnHold(payer);
-            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 1);
+            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 2);
 
             truffleAssert.eventEmitted(tx, 'HoldRenewed', (_event) => {
                 return _event.holdIssuer === payer &&
@@ -1571,6 +1636,67 @@ contract('Holdable', (accounts) => {
                   _event.oldExpiration.toNumber() === originalHold.expiration.toNumber() &&
                   _event.newExpiration.toNumber() === 0
                   ;
+            });
+        });
+
+        it('It should execute and keep open, renew and emit a HoldRenewed when called by the payer with a non zero value', async() => {
+            await holdableInterface.executeHoldAndKeepOpen(operationId, 1, {from: notary});
+            const originalHold = await holdableInterface.retrieveHoldData(operationId);
+            const oldExpiration = originalHold.expiration;
+            const blockTimestamp = await getBlockTimestamp();
+            const newExpiration = blockTimestamp + ONE_WEEK;
+
+            const tx = await holdableInterface.renewHoldWithExpirationDate(
+                operationId,
+                newExpiration,
+                {from: payer}
+            );
+
+            const renewedHold = await holdableInterface.retrieveHoldData(operationId);
+            assert.strictEqual(
+                renewedHold.expiration.toNumber(),
+                newExpiration,
+                'Hold was not renewed correctly'
+            );
+
+            const balanceOnHoldOfPayer = await holdableInterface.balanceOnHold(payer);
+            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 1);
+
+            truffleAssert.eventEmitted(tx, 'HoldRenewed', (_event) => {
+                return _event.holdIssuer === payer &&
+                    _event.operationId === operationId &&
+                    _event.oldExpiration.toNumber() === oldExpiration.toNumber() &&
+                    _event.newExpiration.toNumber() === newExpiration
+                    ;
+            });
+        });
+
+        it('It should execute and keep open, renew and emit a HoldRenewed when called by the payer with a zero value', async() => {
+            await holdableInterface.executeHoldAndKeepOpen(operationId, 1, {from: notary});
+            const originalHold = await holdableInterface.retrieveHoldData(operationId);
+
+            const tx = await holdableInterface.renewHoldWithExpirationDate(
+                operationId,
+                0,
+                {from: payer}
+            );
+
+            const renewedHold = await holdableInterface.retrieveHoldData(operationId);
+            assert.strictEqual(
+                renewedHold.expiration.toNumber(),
+                0,
+                'Hold was not renewed correctly'
+            );
+
+            const balanceOnHoldOfPayer = await holdableInterface.balanceOnHold(payer);
+            assert.strictEqual(balanceOnHoldOfPayer.toNumber(), 1);
+
+            truffleAssert.eventEmitted(tx, 'HoldRenewed', (_event) => {
+                return _event.holdIssuer === payer &&
+                    _event.operationId === operationId &&
+                    _event.oldExpiration.toNumber() === originalHold.expiration.toNumber() &&
+                    _event.newExpiration.toNumber() === 0
+                    ;
             });
         });
     });


### PR DESCRIPTION
Right now we are not allowing to make renews of holds if the status of the hold is on executedAndKeptOpen. 

We only allows if it is in ordered. 
We have to add this status in the require